### PR TITLE
Hackday doc closest

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,31 @@ define(['doc'], function(doc) {
 });
 ```
 
+### closest
+`.closest(querySelector)`
+
+###### Description:
+Get the first ascendant of the Doc object, filtered by querySelector.
+
+###### Parameters:
+> querySelector: String //Should not be a composite. e.g. "#id .class" or "tag.class" due to compatibility issues. Prefer simple selectors. e.g. '.class'. Returns the query's matched elements.
+
+###### Sample:
+``` html
+<form>
+	<fieldset>
+			<input name='name' />
+			<input name='email' />
+	</fieldset>
+</form>
+```
+
+``` js
+define(['doc'], function(doc) {
+	doc('input').closest('form'); //Returns the Doc object form.
+});
+```
+
 #### filter
 `.filter(attribute || callback)`
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,31 @@ define(['doc'], function(doc) {
 });
 ```
 
+### closest
+`.closest(querySelector)`
+
+###### Description:
+Get the first ascendant of the Doc object, filtered by querySelector.
+
+###### Parameters:
+> querySelector: String //Should not be a composite. e.g. "#id .class" or "tag.class" due to compatibility issues. Prefer simple selectors. e.g. '.class'. Returns the query's matched elements.
+
+###### Sample:
+``` html
+<form>
+	<fieldset>
+			<input name='name' />
+			<input name='email' />
+	</fieldset>
+</form>
+```
+
+``` js
+define(['doc'], function(doc) {
+	doc('input').closest('form'); //Returns the Doc object form.
+});
+```
+
 #### filter
 `.filter(attribute || callback)`
 

--- a/doc.js
+++ b/doc.js
@@ -237,7 +237,6 @@ define('doc', ['event'], function(event) {
 
 			'closest' : function(selector) {
 				// only works with non-composite selectors. e.g. '.class' or '#id' or 'div', but not: '#id .class' or 'ul.class'
-				// this implementation is lighter for general selectors like 'div'.
 				var elements = [];
 				var selectorType;
 				var replacedSelector = selector;

--- a/doc.js
+++ b/doc.js
@@ -233,8 +233,8 @@ define('doc', ['event'], function(event) {
 			},
 
 			'closest' : function(selector) {
+				// only works with non-composite selectors. e.g. '.class' or '#id' or 'div', but not: '#id .class' or 'ul.class'
 				var elements = [];
-
 				var selectorType;
 
 				if (matcher.isTag(selector)) {

--- a/doc.js
+++ b/doc.js
@@ -249,9 +249,7 @@ define('doc', ['event'], function(event) {
 				} else if (matcher.isId(selector)) {
 					replacedSelector = selector.replace('#', '');
 					selectorType = 'id';
-				}
-
-				if (!selectorType) {
+				} else {
 					console.warn('You are using composite selectors. e.g. "#id .class" or "tag.class". This selector will only work on Chrome 41+, Firefox 35+ or Opera 28+');
 				}
 
@@ -260,8 +258,8 @@ define('doc', ['event'], function(event) {
 						switch (selectorType) {
 							case 'tag':
 								return (replacedSelector.toUpperCase() === element.tagName)
-								? element
-										: checkForClosestParent(element.parentElement);
+									? element
+									: checkForClosestParent(element.parentElement);
 								break;
 							case 'class':
 								return (query(element).hasClass(replacedSelector))
@@ -288,9 +286,7 @@ define('doc', ['event'], function(event) {
 							elements.push(el);
 						}
 					} else {
-						var el = this.els[i].parentElement;
-
-						var closestParent = checkForClosestParent(el);
+						var closestParent = checkForClosestParent(this.els[i].parentElement);
 						if (closestParent) {
 							elements.push(closestParent);
 						}
@@ -298,10 +294,8 @@ define('doc', ['event'], function(event) {
 				}
 
 				for (var i = elements.length - 1; i > 0; i--) {
-					var elementToBeChecked = elements[i];
 					for (var j = i-1; j >= 0; j--) {
-						var elementToBeCheckedWith = elements[j];
-						if (elementToBeChecked == elementToBeCheckedWith) {
+						if (elements[i] === elements[j]) {
 							elements.pop();
 							break;
 						}

--- a/doc.js
+++ b/doc.js
@@ -253,23 +253,24 @@ define('doc', ['event'], function(event) {
 					console.warn('You are using composite selectors. e.g. "#id .class" or "tag.class". This selector will only work on Chrome 41+, Firefox 35+ or Opera 28+');
 				}
 
-				var checkForClosestParent = function(element) {
+				var checkForClosestParent = function(el) {
+					var element = el.first();
 					if (element) {
 						switch (selectorType) {
 							case 'tag':
 								return (replacedSelector.toUpperCase() === element.tagName)
 									? element
-									: checkForClosestParent(element.parentElement);
+									: checkForClosestParent(el.parent());
 								break;
 							case 'class':
-								return (query(element).hasClass(replacedSelector))
+								return (el.hasClass(replacedSelector))
 									? element
-									: checkForClosestParent(element.parentElement);
+									: checkForClosestParent(el.parent());
 								break;
 							case 'id':
 								return (element.id === replacedSelector)
 									? element
-									: checkForClosestParent(element.parentElement);
+									: checkForClosestParent(el.parent());
 								break;
 							default:
 								throw new SyntaxError("You cannot use composite selector. e.g. 'tag.class' or '#id tag.class tag'. Use simple selectors like '#id', '.class' or 'tag'");
@@ -279,19 +280,20 @@ define('doc', ['event'], function(event) {
 					return null;
 				};
 
-				for (var i = 0; i < this.size; i++) {
-					if (typeof this.els[i].closest === 'function') {
-						var el = this.els[i].closest(selector);
-						if (el) {
-							elements.push(el);
+				this.each(function(el) {
+					if (el.closest === 'function') {
+						var element = el.first();
+						var closestElement = element.closest(selector);
+						if (closestElement) {
+							elemenets.push(el);
 						}
 					} else {
-						var closestParent = checkForClosestParent(this.els[i].parentElement);
-						if (closestParent) {
-							elements.push(closestParent);
+						var closestElement = checkForClosestParent(query(el).parent());
+						if (closestElement) {
+							elements.push(closestElement);
 						}
 					}
-				}
+				});
 
 				for (var i = elements.length - 1; i > 0; i--) {
 					for (var j = i-1; j >= 0; j--) {

--- a/doc.js
+++ b/doc.js
@@ -249,8 +249,6 @@ define('doc', ['event'], function(event) {
 				} else if (matcher.isId(selector)) {
 					replacedSelector = selector.replace('#', '');
 					selectorType = 'id';
-				} else {
-					console.warn('You are using composite selectors. e.g. "#id .class" or "tag.class". This selector will only work on Chrome 41+, Firefox 35+ or Opera 28+');
 				}
 
 				var checkForClosestParent = function(el) {
@@ -296,7 +294,7 @@ define('doc', ['event'], function(event) {
 				});
 
 				for (var i = elements.length - 1; i > 0; i--) {
-					for (var j = i-1; j >= 0; j--) {
+					for (var j = i - 1; j >= 0; j--) {
 						if (elements[i] === elements[j]) {
 							elements.pop();
 							break;

--- a/doc.js
+++ b/doc.js
@@ -296,7 +296,7 @@ define('doc', ['event'], function(event) {
 					}
 				}
 
-				return elements;
+				return query(elements);
 			},
 
 			'find' : function(selector) {

--- a/doc.js
+++ b/doc.js
@@ -8,6 +8,9 @@ define('doc', ['event'], function(event) {
 		},
 		isId : function(selector) {
 			return selector.match(/^#[\w-]+$/);
+		},
+		isTagWithClass : function(selector) {
+			return selector.match(/[\w+\.\w+]+/)
 		}
 	};
 
@@ -234,6 +237,7 @@ define('doc', ['event'], function(event) {
 
 			'closest' : function(selector) {
 				// only works with non-composite selectors. e.g. '.class' or '#id' or 'div', but not: '#id .class' or 'ul.class'
+				// this implementation is lighter for general selectors like 'div'.
 				var elements = [];
 				var selectorType;
 
@@ -248,6 +252,7 @@ define('doc', ['event'], function(event) {
 				}
 
 				if (!selectorType) {
+					throw "You cannot use composite selector. e.g. 'tag.class' or '#id tag.class tag'. Use simple selectors like '#id', '.class' or 'tag'";
 					return null;
 				}
 
@@ -256,8 +261,8 @@ define('doc', ['event'], function(event) {
 						switch (selectorType) {
 							case 'tag':
 								return (selector.toUpperCase() === element.tagName)
-									? element
-									: checkForClosestParent(element.parentElement);
+								? element
+										: checkForClosestParent(element.parentElement);
 								break;
 							case 'class':
 								return ($(element).hasClass(selector))

--- a/doc.js
+++ b/doc.js
@@ -265,7 +265,7 @@ define('doc', ['event'], function(event) {
 										: checkForClosestParent(element.parentElement);
 								break;
 							case 'class':
-								return ($(element).hasClass(replacedSelector))
+								return (query(element).hasClass(replacedSelector))
 									? element
 									: checkForClosestParent(element.parentElement);
 								break;

--- a/doc.js
+++ b/doc.js
@@ -234,6 +234,7 @@ define('doc', ['event'], function(event) {
 
 			'closest' : function(selector) {
 				var elements = [];
+
 				var selectorType;
 
 				if (matcher.isTag(selector)) {
@@ -281,6 +282,17 @@ define('doc', ['event'], function(event) {
 					var closestParent = checkForClosestParent(el);
 					if (closestParent) {
 						elements.push(closestParent);
+					}
+				}
+
+				for (var i = elements.length - 1; i > 0; i--) {
+					var elementToBeChecked = elements[i];
+					for (var j = i-1; j >= 0; j--) {
+						var elementToBeCheckedWith = elements[j];
+						if (elementToBeChecked == elementToBeCheckedWith) {
+							elements.pop();
+							break;
+						}
 					}
 				}
 

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -77,7 +77,6 @@
       mocha.ui("bdd");
 
       define(['doc'], function($) {
-        window.$ = $;
         describe('Doc', function(){
           it('should contains all known methods', function(){
             var current = [];

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -78,7 +78,7 @@
 
       define(['doc'], function($) {
         describe('Doc', function(){
-          it("should contains all known methods", function(){
+          it('should contains all known methods', function(){
             var current = [];
             for(var methodName in $("body")) current.push(methodName);
             assert.equal(arrayEquals(knownMethods(), current), true);
@@ -135,7 +135,7 @@
             assert.equal( $('#hiddenInput').val(),"valor inserido");
           });
 
-          it("should find the correct elements", function(){
+          it('should find the correct elements', function(){
             assert.equal($('#find-element').find('.find').size, 2);
             assert.equal($('#find-element').find('.find-1').size, 1);
             assert.equal($('#find-element').find('.sub-find').size, 2);
@@ -144,7 +144,7 @@
             assert.equal($('#find-element').find('#sub-find-2').size, 1);
           });
 
-          it("should find the closest elements", function() {
+          it('should find the closest elements', function() {
             assert.equal($('.sub-find').closest('.find').size, 2);
             assert.equal($('#sub-find-2').closest('#find-element').size, 1);
             assert.equal($('.find').closest('#find-element').size, 1);
@@ -152,7 +152,7 @@
             assert.equal($('.child-div').closest('div').hasClass('not-this-one'), false);
           });
 
-          it("should filter the checkbox checked", function() {
+          it('should filter the checkbox checked', function() {
             assert.equal($('#test-suite .checked').filter('checked').size, 1);
             var count = 0;
             $('#test-suite .checked').filter(function(field){
@@ -198,7 +198,7 @@
             assert.equal( $("#fire-event-test").first().innerHTML,"PONG");
           });
 
-          it("should remove event with function *off*", function() {
+          it('should remove event with function *off*', function() {
             var count = 0;
             $("#off-button").on('click', function(){
               $("#off-count").val(++count);
@@ -207,20 +207,20 @@
             fireEvent($("#off-button").first(), "click");
             assert.equal( $("#off-count").val(), 1);
 
-            $("#off-button").off('click');
+            $('#off-button').off('click');
             fireEvent($("#off-button").first(), "click");
             assert.equal( $("#off-count").val(), 1);
           });
 
-          it("should remove event with function *off* using a named", function() {
+          it('should remove event with function *off* using a named', function() {
             var count = 0;
-            $("#off-button").on('click', function(){
-              $("#off-count").val(++count);
-            }, "named-1");
+            $('#off-button').on('click', function(){
+              $('#off-count').val(++count);
+            }, 'named-1');
 
-            $("#off-button").on('click', function(){
-              $("#off-count").val(++count);
-            }, "named-2");
+            $('#off-button').on('click', function(){
+              $('#off-count').val(++count);
+            }, 'named-2');
 
             fireEvent($("#off-button").first(), "click");
             assert.equal( $("#off-count").val(), 2);

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -77,6 +77,7 @@
       mocha.ui("bdd");
 
       define(['doc'], function($) {
+        window.$ = $;
         describe('Doc', function(){
           it('should contains all known methods', function(){
             var current = [];

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -27,6 +27,15 @@
         </div>
       </div>
 
+      <div class='not-this-one'>
+        Elemento a não ser escolhido
+        <div class='this-one'>
+          Elemento a ser encontrado pelo closest
+          <div class='child-div'>
+          </div>
+        </div>
+      </div>
+
       <div id="append-div"></div>
 
       <input class="checked" type="checkbox" checked>
@@ -139,6 +148,8 @@
             assert.equal($('.sub-find').closest('.find').size, 2);
             assert.equal($('#sub-find-2').closest('#find-element').size, 1);
             assert.equal($('.find').closest('#find-element').size, 1);
+            assert.equal($('.child-div').closest('div').hasClass('this-one'), true);
+            assert.equal($('.child-div').closest('div').hasClass('not-this-one'), false);
           });
 
           it("should filter the checkbox checked", function() {

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -135,6 +135,12 @@
             assert.equal($('#find-element').find('#sub-find-2').size, 1);
           });
 
+          it("should find the closest elements", function() {
+            assert.equal($('.sub-find').closest('.find').size, 2);
+            assert.equal($('#sub-find-2').closest('#find-element').size, 1);
+            assert.equal($('.find').closest('#find-element').size, 1);
+          });
+
           it("should filter the checkbox checked", function() {
             assert.equal($('#test-suite .checked').filter('checked').size, 1);
             var count = 0;
@@ -311,6 +317,7 @@
           'removeItem',
           'find',
           'filter',
+          'closest',
           'first',
           'last',
           'previous',


### PR DESCRIPTION
This patch adds the 'closest' method for Doc. Similar to jQuery one.
Since last update, composite selectors are now fully supported.

This patch contains:
- .closest() implementation;
- README.md updates with description and
- tests for closest() method.
