### PR TITLE
Evaluates NodeList and HTMLCollection properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Doc-amd also depends on [events-amd](https://github.com/elo7/event-amd).
 
 #### doc
 `doc(querySelector)`
+`doc(HTMLCollection)`
+`doc(NodeList)`
+`doc(Array)`
+`doc(Node)`
 
 ###### Description:
 Returns a Doc object with all the methods below.
@@ -41,6 +45,10 @@ define(['doc'], function(doc) {
 	doc('#link')
 	doc('a')
 	doc('li > a')
+	doc(document.body.children)
+	doc(document.body.childNodes)
+	doc(document.body)
+	doc([document.head, document.body])
 });
 ```
 

--- a/doc.js
+++ b/doc.js
@@ -21,25 +21,25 @@ define('doc', ['event'], function(event) {
 	var search = function(namespace, selector) {
 		var selector = selector.replace(/^\s+|\s+$/g, '');
 		if (matcher.isTag(selector)) {
-			return convertToArray(namespace.getElementsByTagName(selector));
+			return convertHtmlCollectionToArray(namespace.getElementsByTagName(selector));
 		} else if(matcher.isId(selector)) {
 			selector = selector.replace('#', '');
 			return document.getElementById(selector);
 		} else if (matcher.isClass(selector) && namespace.getElementsByClassName) {
 			selector = selector.replace('.', '');
-			return convertToArray(namespace.getElementsByClassName(selector));
+			return convertHtmlCollectionToArray(namespace.getElementsByClassName(selector));
 		}
-		return convertToArray(namespace.querySelectorAll(selector));
+		return convertHtmlCollectionToArray(namespace.querySelectorAll(selector));
 	};
 
-	var convertToArray = function(nodeList) {
+	var convertHtmlCollectionToArray = function(htmlCollection) {
 		try {
 			return Array.prototype.slice.call(namespace.getElementsByTagName(selector));
 		} catch(e) {
 			var array = [];
-			var length = nodeList.length;
+			var length = htmlCollection.length;
 			for(var i = 0; i < length; i++) {
-				array.push(nodeList[i]);
+				array.push(htmlCollection[i]);
 			}
 			return array;
 		}
@@ -77,12 +77,28 @@ define('doc', ['event'], function(event) {
 		return el.className.match(new RegExp('(^|\\s)' + clazz + '($|\\s)'));
 	};
 
+	var convertNodeListToArray = function(nodeList) {
+		var length = nodeList.length;
+		var list = [];
+		for (var i = 0; i < length ; i++) {
+			var element = nodeList[i];
+			if (element.nodeType === Node.ELEMENT_NODE) {
+				list.push(element);
+			}
+		}
+		return list;
+	}
+
 	var query = function(elements) {
 		var selectedElements = [];
 
-		if (elements){
+		if (elements) {
 			if (elements instanceof Array) {
 				selectedElements = elements;
+			} else if (elements instanceof HTMLCollection) {
+				selectedElements = convertHtmlCollectionToArray(elements);
+			} else if (elements instanceof NodeList) {
+				selectedElements = convertNodeListToArray(elements);
 			} else {
 				selectedElements.push(elements);
 			}

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -393,6 +393,11 @@
             var element = $("#find-element").first();
             assert.equal($(element.childNodes).size, 2);
           });
+
+          it("should handle an array of elements as an array of elements", function() {
+            var elements = [document.head, document.body];
+            assert.equal($(elements).size, 2);
+          });
         });
       });
     </script>

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -383,6 +383,16 @@
             $.broadcast('say hello to my little friend', data);
             assert.equal(counter, 6);
           });
+
+          it("should handle HTMLCollection as an array of elements", function() {
+            var element = $("#find-element").first();
+            assert.equal($(element.children).size, 2);
+          });
+
+          it("should handle NodeList as an array of elements, filtering not elements", function() {
+            var element = $("#find-element").first();
+            assert.equal($(element.childNodes).size, 2);
+          });
         });
       });
     </script>


### PR DESCRIPTION
👍   @diegocesar
Closes #2 
# Changelog
- When passing an instance of `NodeList` to `$()`, evaluates it as an Array and filters non-element nodes
- When passing an instance of `HTMLColleciton` to `$()`, evaluates it as an Array.

@leocwolter @luiz 
