### PR TITLE
Implements scrollIntoView

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,23 @@ define(['doc'], function(doc) {
 });
 ```
 
+#### scrollIntoView
+`.scrollIntoView([options])`
+
+###### Description:
+Makes the first element matched by Doc visible at the top of the viewport.
+
+###### Parameters:
+> options: boolean //To indicate whether the element should be aligned to the top of the visible area (default) or to the bottom
+>          object //An object with the properties _block_ ("start" or "end", indicating the same as the boolean version above) and _behavior_ ("auto" or "instant" or "smooth")
+
+###### Sample:
+``` js
+define(['doc'], function(doc) {
+	doc('div').scrollIntoView(); //Scroll until the first matched div appears at the top of the viewport
+});
+```
+
 ## License
 
 Doc-amd is released under the [BSD](https://github.com/elo7/doc-amd/blob/master/LICENSE). Have at it.

--- a/doc.js
+++ b/doc.js
@@ -408,8 +408,9 @@ define('doc', ['event'], function(event) {
 				return this;
 			},
 
-			'scrollIntoView' : function() {
-				this.els[0].scrollIntoView();
+			'scrollIntoView' : function(scrollIntoViewOptions) {
+				var scrollIntoViewOptions = scrollIntoViewOptions || true;
+				this.els[0].scrollIntoView(scrollIntoViewOptions);
 				return this;
 			}
 		}

--- a/doc.js
+++ b/doc.js
@@ -406,6 +406,11 @@ define('doc', ['event'], function(event) {
 					el.removeAttribute(attrName);
 				});
 				return this;
+			},
+
+			'scrollIntoView' : function() {
+				this.els[0].scrollIntoView();
+				return this;
 			}
 		}
 	}

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -6,8 +6,6 @@
     <link href="/css/mocha.css" type="text/css" rel="stylesheet"/>
   </head>
   <body>
-    <div id="mocha"></div>
-
     <div id="test-suite">
       <div id="parent-element">
         <div id="first-el">Primeiro Elemento</div>
@@ -68,6 +66,8 @@
 
       <a href='#not-removed' id='remove-my-href'>click</a>
     </div>
+
+    <div id="mocha"></div>
 
     <script src="/node_modules/mocha/mocha.js"></script>
     <script src="/node_modules/proclaim/lib/proclaim.js"></script>

--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -353,6 +353,12 @@
             var element = $("#remove-my-href");
             assert.doesNotThrow(function() { element.removeAttr("style") });
           });
+
+          it('should scroll viewport until the first matched element is at the top of the viewport', function() {
+            var elements = $('.checked');
+            elements.scrollIntoView();
+            assert.equal(elements.first().getBoundingClientRect().top, 0);
+          });
         });
       });
     </script>
@@ -395,7 +401,8 @@
           'trigger',
           'selectedText',
           'focus',
-          'removeAttr'
+          'removeAttr',
+          'scrollIntoView'
         ];
       }
     </script>


### PR DESCRIPTION
Closes #14 
# Changelog
- Adds method `scrollIntoView`, which scrolls the viewport to make the first matched element visible at the top (or the closest possible to it) of the viewport

@leocwolter @luiz 
