### PR TITLE
Allows less than 1 px from top when testing `scrollIntoView`

### DIFF
--- a/test/docTest.js.html
+++ b/test/docTest.js.html
@@ -360,7 +360,7 @@
           it('should scroll viewport until the first matched element is at the top of the viewport', function() {
             var elements = $('.checked');
             elements.scrollIntoView();
-            assert.equal(elements.first().getBoundingClientRect().top, 0);
+            assert.lessThan(Math.abs(elements.first().getBoundingClientRect().top), 1);
           });
 
           it("should select an element with an id with dot", function() {


### PR DESCRIPTION
👍 @mottam

Closes #26

As Firefox and IE >= 10 don't put the scrolled-into-view element exactly at the top, makes the test a little more flexible, allowing for a difference of less than 1px from the top of the window.

@luiz
