### PR TITLE
Changing events-amd version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-amd",
-  "version": "1.0.14-SNAPSHOT",
+  "version": "1.0.14",
   "homepage": "https://github.com/elo7/doc-amd",
   "description": "A small DOM manipulation library",
   "main": "doc.js",
@@ -24,7 +24,7 @@
     "css"
   ],
   "dependencies": {
-    "events-amd": "elo7/events-amd"
+    "events-amd": "elo7/events-amd#f1dbe6e019ec91f4691037962c375623c84159b2"
   },
   "devDependencies": {
     "async-define": "elo7/async-define"

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "css"
   ],
   "dependencies": {
-    "events-amd": "elo7/events-amd#f1dbe6e019ec91f4691037962c375623c84159b2"
+    "events-amd": "1.1.0"
   },
   "devDependencies": {
     "async-define": "elo7/async-define"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-unit-tests",
-  "version": "1.0.14-SNAPSHOT",
+  "version": "1.0.14",
   "description": "Elo7 doc js unit tests",
   "keywords": [
     "JS",


### PR DESCRIPTION
🤙 @tcelestino

@mottam

Since last Chrome's update, we've been experiencing issues on touch events registration. In this PR we include a new events-amd's version in which this is no longer an issue.

💣 Depends on https://github.com/elo7/events-amd/pull/3

⚠️ Remember to update `bower.json` when the dependency is properly deployed.